### PR TITLE
[squid:S1155] Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/okcoin-client-xchange/src/main/java/org/oxerr/okcoin/xchange/service/fix/OKCoinXChangeApplication.java
+++ b/okcoin-client-xchange/src/main/java/org/oxerr/okcoin/xchange/service/fix/OKCoinXChangeApplication.java
@@ -173,11 +173,11 @@ public class OKCoinXChangeApplication extends OKCoinApplication {
 			}
 		}
 
-		if (asks.size() > 0 && bids.size() > 0) {
+		if (!asks.isEmpty() && !bids.isEmpty()) {
 			onOrderBook(origTime, asks, bids, sessionId);
 		}
 
-		if (trades.size() > 0) {
+		if (!trades.isEmpty()) {
 			onTrades(trades, sessionId);
 		}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.
Ayman Abdelghany.
