### PR TITLE
[squid:S2111] "BigDecimal(double)" should not be used

### DIFF
--- a/okcoin-client-fix/src/main/java/org/oxerr/okcoin/fix/field/FreeBtc.java
+++ b/okcoin-client-fix/src/main/java/org/oxerr/okcoin/fix/field/FreeBtc.java
@@ -19,7 +19,7 @@ public class FreeBtc extends DecimalField {
 	}
 
 	public FreeBtc(double data) {
-		super(FIELD, new BigDecimal(data));
+		super(FIELD, BigDecimal.valueOf(data));
 	}
 
 }

--- a/okcoin-client-fix/src/main/java/org/oxerr/okcoin/fix/field/FreeLtc.java
+++ b/okcoin-client-fix/src/main/java/org/oxerr/okcoin/fix/field/FreeLtc.java
@@ -19,7 +19,7 @@ public class FreeLtc extends DecimalField {
 	}
 
 	public FreeLtc(double data) {
-		super(FIELD, new BigDecimal(data));
+		super(FIELD, BigDecimal.valueOf(data));
 	}
 
 }

--- a/okcoin-client-fix/src/main/java/org/oxerr/okcoin/fix/field/FreeQtCcy.java
+++ b/okcoin-client-fix/src/main/java/org/oxerr/okcoin/fix/field/FreeQtCcy.java
@@ -22,7 +22,7 @@ public class FreeQtCcy extends DecimalField {
 	}
 
 	public FreeQtCcy(double data) {
-		super(FIELD, new BigDecimal(data));
+		super(FIELD, BigDecimal.valueOf(data));
 	}
 
 }

--- a/okcoin-client-fix/src/main/java/org/oxerr/okcoin/fix/field/FrozenBtc.java
+++ b/okcoin-client-fix/src/main/java/org/oxerr/okcoin/fix/field/FrozenBtc.java
@@ -19,7 +19,7 @@ public class FrozenBtc extends DecimalField {
 	}
 
 	public FrozenBtc(double data) {
-		super(FIELD, new BigDecimal(data));
+		super(FIELD, BigDecimal.valueOf(data));
 	}
 
 }

--- a/okcoin-client-fix/src/main/java/org/oxerr/okcoin/fix/field/FrozenLtc.java
+++ b/okcoin-client-fix/src/main/java/org/oxerr/okcoin/fix/field/FrozenLtc.java
@@ -19,7 +19,7 @@ public class FrozenLtc extends DecimalField {
 	}
 
 	public FrozenLtc(double data) {
-		super(FIELD, new BigDecimal(data));
+		super(FIELD, BigDecimal.valueOf(data));
 	}
 
 }

--- a/okcoin-client-fix/src/main/java/org/oxerr/okcoin/fix/field/FrozenQtCcy.java
+++ b/okcoin-client-fix/src/main/java/org/oxerr/okcoin/fix/field/FrozenQtCcy.java
@@ -22,7 +22,7 @@ public class FrozenQtCcy extends DecimalField {
 	}
 
 	public FrozenQtCcy(double data) {
-		super(FIELD, new BigDecimal(data));
+		super(FIELD, BigDecimal.valueOf(data));
 	}
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2111 - “ "BigDecimal(double)" should not be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2111

Please let me know if you have any questions.
Ayman Abdelghany.
