### PR TITLE
[squid:S2293] The operator ("<>") should be used.

### DIFF
--- a/okcoin-client-rest/src/main/java/org/oxerr/okcoin/rest/dto/TradeParam.java
+++ b/okcoin-client-rest/src/main/java/org/oxerr/okcoin/rest/dto/TradeParam.java
@@ -113,7 +113,7 @@ public class TradeParam extends BaseObject {
 	}
 
 	public List<NameValuePair> toNameValurPairs() {
-		List<NameValuePair> params = new ArrayList<NameValuePair>(5);
+		List<NameValuePair> params = new ArrayList<>(5);
 		params.add(new BasicNameValuePair("tradeAmount", getTradeAmount().toPlainString()));
 		params.add(new BasicNameValuePair("tradeCnyPrice", getTradeCnyPrice().toPlainString()));
 		params.add(new BasicNameValuePair("tradePwd", getTradePwd()));

--- a/okcoin-client-rest/src/main/java/org/oxerr/okcoin/rest/service/polling/OKCoinBaseTradePollingService.java
+++ b/okcoin-client-rest/src/main/java/org/oxerr/okcoin/rest/service/polling/OKCoinBaseTradePollingService.java
@@ -38,7 +38,7 @@ public class OKCoinBaseTradePollingService extends OKCoinBasePollingService {
 
 	protected final String apiKey;
 
-	private Map<String, Long> lasts = new HashMap<String, Long>();
+	private Map<String, Long> lasts = new HashMap<>();
 
 	protected final OKCoinClient okCoinClient;
 	protected final int loginMaxRetryTimes;

--- a/okcoin-client-rest/src/main/java/org/oxerr/okcoin/rest/service/web/HttpClient.java
+++ b/okcoin-client-rest/src/main/java/org/oxerr/okcoin/rest/service/web/HttpClient.java
@@ -75,11 +75,11 @@ public class HttpClient implements AutoCloseable {
 	}
 
 	public <T> T get(URI uri, Class<T> valueType) throws IOException {
-		return get(uri, new JsonValueReader<T>(objectMapper, valueType));
+		return get(uri, new JsonValueReader<>(objectMapper, valueType));
 	}
 
 	public <T> T get(URI uri, TypeReference<T> valueTypeRef) throws IOException {
-		return get(uri, new JsonValueTypeRefReader<T>(objectMapper, valueTypeRef));
+		return get(uri, new JsonValueTypeRefReader<>(objectMapper, valueTypeRef));
 	}
 
 	public <T> T get(URI uri, ValueReader<T> valueReader) throws IOException {

--- a/okcoin-client-websocket/src/main/java/org/oxerr/okcoin/websocket/OKCoinDecoder.java
+++ b/okcoin-client-websocket/src/main/java/org/oxerr/okcoin/websocket/OKCoinDecoder.java
@@ -38,7 +38,7 @@ public class OKCoinDecoder implements Decoder.TextStream<OKCoinData[]> {
 	private final Map<String, Class<?>> types;
 
 	public OKCoinDecoder() {
-		types = new HashMap<String, Class<?>>();
+		types = new HashMap<>();
 		for (String symbol : new String[] {"btccny", "ltccny"}) {
 			types.put(String.format("ok_%s_ticker", symbol), Ticker.class);
 			types.put(String.format("ok_%s_depth", symbol), Depth.class);

--- a/okcoin-client-xchange/src/main/java/org/oxerr/okcoin/xchange/service/fix/OKCoinXChangeApplication.java
+++ b/okcoin-client-xchange/src/main/java/org/oxerr/okcoin/xchange/service/fix/OKCoinXChangeApplication.java
@@ -122,9 +122,9 @@ public class OKCoinXChangeApplication extends OKCoinApplication {
 		log.debug("Symbol: {}, currency pair: {}", symbol, currencyPair);
 		log.debug("MDReqID: {}", mdReqId);
 
-		List<LimitOrder> asks = new ArrayList<LimitOrder>();
-		List<LimitOrder> bids = new ArrayList<LimitOrder>();
-		List<Trade> trades = new ArrayList<Trade>();
+		List<LimitOrder> asks = new ArrayList<>();
+		List<LimitOrder> bids = new ArrayList<>();
+		List<Trade> trades = new ArrayList<>();
 		BigDecimal openingPrice = null, closingPrice = null,
 			highPrice = null, lowPrice = null,
 			vwapPrice = null, lastPrice = null,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293

Please let me know if you have any questions.
Ayman Abdelghany.
